### PR TITLE
Add support for Python packages with epoch version

### DIFF
--- a/python/spec/dependabot/python/version_spec.rb
+++ b/python/spec/dependabot/python/version_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe Dependabot::Python::Version do
       let(:version_string) { "1.0.0" }
       it { is_expected.to eq(true) }
 
+      context "that includes a non-zero epoch" do
+        let(:version_string) { "1!1.0.0" }
+        it { is_expected.to eq(true) }
+      end
+
       context "that includes a local version" do
         let(:version_string) { "1.0.0+abc.1" }
         it { is_expected.to eq(true) }
@@ -76,6 +81,11 @@ RSpec.describe Dependabot::Python::Version do
       context "that is lower" do
         let(:other_version) { Gem::Version.new("0.9.0") }
         it { is_expected.to eq(1) }
+
+        context "because our version has a non-zero epoch" do
+          let(:version_string) { "1!0.9.0" }
+          it { is_expected.to eq(1) }
+        end
       end
 
       context "that is equal" do
@@ -103,11 +113,39 @@ RSpec.describe Dependabot::Python::Version do
       context "that is lower" do
         let(:other_version) { described_class.new("0.9.0") }
         it { is_expected.to eq(1) }
+
+        context "because our version has a non-zero epoch" do
+          let(:version_string) { "1!0.9.0" }
+          it { is_expected.to eq(1) }
+        end
+
+        context "because our version has a greater epoch" do
+          let(:version_string) { "2!0.9.0" }
+          let(:other_version) { described_class.new("1!0.9.0") }
+          it { is_expected.to eq(1) }
+        end
       end
 
       context "that is equal" do
         let(:other_version) { described_class.new("1.0.0") }
         it { is_expected.to eq(0) }
+
+        context "but our version has a non-zero epoch" do
+          let(:version_string) { "1!1.0.0" }
+          it { is_expected.to eq(1) }
+        end
+
+        context "but the other version has a non-zero epoch" do
+          let(:version_string) { "1.0.0" }
+          let(:other_version) { described_class.new("1!1.0.0") }
+          it { is_expected.to eq(-1) }
+        end
+
+        context "and both versions have a non-zero epoch" do
+          let(:version_string) { "1!1.0.0" }
+          let(:other_version) { described_class.new("1!1.0.0") }
+          it { is_expected.to eq(0) }
+        end
 
         context "but our version has a local version" do
           let(:version_string) { "1.0.0+gc.1" }
@@ -182,6 +220,12 @@ RSpec.describe Dependabot::Python::Version do
       context "that is greater" do
         let(:other_version) { described_class.new("1.1.0") }
         it { is_expected.to eq(-1) }
+
+        context "and both versions have a non-zero epoch" do
+          let(:version_string) { "1!1.1.0" }
+          let(:other_version) { described_class.new("2!1.1.0") }
+          it { is_expected.to eq(-1) }
+        end
 
         context "with a dash that needs sanitizing" do
           let(:version_string) { "0.5.4-alpha" }


### PR DESCRIPTION
Dependabot currently considers a Python package version with an epoch to be illformed. See definition here https://peps.python.org/pep-0440/#version-epochs.
This change adds support for parsing them and using epochs in version comparisons. Where one is not specified, the epoch is treated as 0.